### PR TITLE
Revision 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox-adapter",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox-adapter",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox-adapter",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Integrate Valibot and Zod with TypeBox",
   "author": "sinclairzx81",
   "license": "MIT",

--- a/task/build/esm/convert-to-esm.ts
+++ b/task/build/esm/convert-to-esm.ts
@@ -32,7 +32,15 @@ import * as Fs from 'node:fs'
 // ------------------------------------------------------------------
 // Specifier Rewrite
 // ------------------------------------------------------------------
-
+function shouldSkipSpecifier(captured: string) {
+  const specifier = captured.slice(1, captured.length - 1)
+  return (
+    specifier.includes('.mjs') || // mitigate duplicate rewrite 
+    specifier.startsWith("@sinclair/typebox") || 
+    specifier.startsWith("valibot") || 
+    specifier.startsWith("zod")
+  )
+}
 // prettier-ignore
 function replaceInlineImportSpecifiers(content: string): string {
   const pattern = /import\((.*?)\)/g
@@ -40,7 +48,7 @@ function replaceInlineImportSpecifiers(content: string): string {
     const match = pattern.exec(content)
     if (match === null) return content
     const captured = match[1]
-    if(captured.includes('.mjs')) continue
+    if(shouldSkipSpecifier(captured)) continue
     const specifier = captured.slice(1, captured.length - 1)
     content = content.replace(captured, `"${specifier}.mjs"`)
   }
@@ -52,6 +60,7 @@ function replaceExportSpecifiers(content: string): string {
     const match = pattern.exec(content)
     if(match === null) return content
     const captured = match[3]
+    if(shouldSkipSpecifier(captured)) continue
     const specifier = captured.slice(1, captured.length - 1)
     content = content.replace(captured, `'${specifier}.mjs'`)
   }


### PR DESCRIPTION
This PR fixes the Esm Specifier rewrite to ignore Typebox, Zod and Valibot import paths. 

Fixes: https://github.com/sinclairzx81/typebox-adapter/issues/3